### PR TITLE
Update the latest SkiaSharp version for Azure App Service conversion samples

### DIFF
--- a/Word-to-Image-conversion/Convert-Word-to-image/Azure/Azure_App_Service/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
+++ b/Word-to-Image-conversion/Convert-Word-to-image/Azure/Azure_App_Service/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.2" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
     <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/Azure/Azure_App_Service/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/Azure/Azure_App_Service/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.2" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
     <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 


### PR DESCRIPTION
Update the latest SkiaSharp version for Azure App Service conversion samples:

- Word to PDF
- Word to Image

[SkiaSharp.NativeAssets.Linux v2.88.6](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux/2.88.6)
[HarfBuzzSharp.NativeAssets.Linux v7.3.0](https://www.nuget.org/packages/HarfBuzzSharp.NativeAssets.Linux/7.3.0)