### PR TITLE
Update the latest SkiaSharp version for Linux conversion samples

### DIFF
--- a/FAQs/Copy-fonts-to-linux-containers/Copy-fonts-to-linux-containers.csproj
+++ b/FAQs/Copy-fonts-to-linux-containers/Copy-fonts-to-linux-containers.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0-preview.209" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2-preview.209" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0" />
     <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 

--- a/FAQs/Copy-fonts-to-linux-containers/Dockerfile
+++ b/FAQs/Copy-fonts-to-linux-containers/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:3.1-bionic AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0-jammy AS base
 RUN apt-get update -y && apt-get install fontconfig -y
 WORKDIR /app
 #Copy fonts to linux containers from a folder.
 COPY ["Fonts/*.*", "/usr/local/share/fonts/"]
-FROM mcr.microsoft.com/dotnet/sdk:3.1-bionic AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
 WORKDIR /src
 COPY ["Copy-fonts-to-linux-containers.csproj", "."]
 RUN dotnet restore "./Copy-fonts-to-linux-containers.csproj"

--- a/Word-to-Image-conversion/Convert-Word-to-image/Linux/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
+++ b/Word-to-Image-conversion/Convert-Word-to-image/Linux/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.2" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
     <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 


### PR DESCRIPTION
Update the latest SkiaSharp version for Linux conversion samples:

- Copy fonts to linux containers
- Word to Image

[SkiaSharp.NativeAssets.Linux v2.88.6](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux/2.88.6)
[HarfBuzzSharp.NativeAssets.Linux v7.3.0](https://www.nuget.org/packages/HarfBuzzSharp.NativeAssets.Linux/7.3.0)