### PR TITLE
Upgrade the NuGet version to 28.1.33 in all .NET Framework projects - DocIO Examples

### DIFF
--- a/Bookmarks/Delete-content-between-two-bookmarks/.NET-Framework/Delete-content-between-two-bookmarks.csproj
+++ b/Bookmarks/Delete-content-between-two-bookmarks/.NET-Framework/Delete-content-between-two-bookmarks.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Bookmarks/Delete-content-between-two-bookmarks/.NET-Framework/packages.config
+++ b/Bookmarks/Delete-content-between-two-bookmarks/.NET-Framework/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Charts/Convert-chart-to-image/.NET-Framework/Convert-chart-to-image/Convert-chart-to-image.csproj
+++ b/Charts/Convert-chart-to-image/.NET-Framework/Convert-chart-to-image/Convert-chart-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Charts/Convert-chart-to-image/.NET-Framework/Convert-chart-to-image/packages.config
+++ b/Charts/Convert-chart-to-image/.NET-Framework/Convert-chart-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Charts/Create-Pie-chart-from-database/.NET-Framework/Create-Pie-chart-from-database/Create-Pie-chart-from-database.csproj
+++ b/Charts/Create-Pie-chart-from-database/.NET-Framework/Create-Pie-chart-from-database/Create-Pie-chart-from-database.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Charts/Create-Pie-chart-from-database/.NET-Framework/Create-Pie-chart-from-database/packages.config
+++ b/Charts/Create-Pie-chart-from-database/.NET-Framework/Create-Pie-chart-from-database/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
   <package id="System.Data.OleDb" version="8.0.0" targetFramework="net472" />
 </packages>

--- a/Charts/Create-clustered-bar-chart-using-dynamic-data/.NET-Framework/Create-clustered-bar-chart-using-dynamic-data/Create-clustered-bar-chart-using-dynamic-data.csproj
+++ b/Charts/Create-clustered-bar-chart-using-dynamic-data/.NET-Framework/Create-clustered-bar-chart-using-dynamic-data/Create-clustered-bar-chart-using-dynamic-data.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Charts/Create-clustered-bar-chart-using-dynamic-data/.NET-Framework/Create-clustered-bar-chart-using-dynamic-data/packages.config
+++ b/Charts/Create-clustered-bar-chart-using-dynamic-data/.NET-Framework/Create-clustered-bar-chart-using-dynamic-data/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/FAQs/Find-used-fonts-in-word-document/.NET-Framework/Find-used-fonts-in-word-document/Find-used-fonts-in-word-document.csproj
+++ b/FAQs/Find-used-fonts-in-word-document/.NET-Framework/Find-used-fonts-in-word-document/Find-used-fonts-in-word-document.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/FAQs/Find-used-fonts-in-word-document/.NET-Framework/Find-used-fonts-in-word-document/packages.config
+++ b/FAQs/Find-used-fonts-in-word-document/.NET-Framework/Find-used-fonts-in-word-document/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Find-and-Replace/Replace-text-in-Word-with-HTML/.NET-Framework/Replace-text-in-Word-with-HTML/Replace-text-in-Word-with-HTML.csproj
+++ b/Find-and-Replace/Replace-text-in-Word-with-HTML/.NET-Framework/Replace-text-in-Word-with-HTML/Replace-text-in-Word-with-HTML.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Find-and-Replace/Replace-text-in-Word-with-HTML/.NET-Framework/Replace-text-in-Word-with-HTML/packages.config
+++ b/Find-and-Replace/Replace-text-in-Word-with-HTML/.NET-Framework/Replace-text-in-Word-with-HTML/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Find-and-Replace/Replace-text-in-headers-and-footers/.NET-Framework/Replace-text-in-headers-and-footers/Replace-text-in-headers-and-footers.csproj
+++ b/Find-and-Replace/Replace-text-in-headers-and-footers/.NET-Framework/Replace-text-in-headers-and-footers/Replace-text-in-headers-and-footers.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Find-and-Replace/Replace-text-in-headers-and-footers/.NET-Framework/Replace-text-in-headers-and-footers/packages.config
+++ b/Find-and-Replace/Replace-text-in-headers-and-footers/.NET-Framework/Replace-text-in-headers-and-footers/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Getting-Started/.NET-Framework/Create-Word-document/Create-Word-document.csproj
+++ b/Getting-Started/.NET-Framework/Create-Word-document/Create-Word-document.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Getting-Started/.NET-Framework/Create-Word-document/packages.config
+++ b/Getting-Started/.NET-Framework/Create-Word-document/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Getting-Started/ASP.NET-MVC/Create-Word-document/Create-Word-document.csproj
+++ b/Getting-Started/ASP.NET-MVC/Create-Word-document/Create-Word-document.csproj
@@ -46,17 +46,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Getting-Started/ASP.NET-MVC/Create-Word-document/Web.config
+++ b/Getting-Started/ASP.NET-MVC/Create-Word-document/Web.config
@@ -18,6 +18,7 @@
     <httpRuntime targetFramework="4.6.2" />
     <httpHandlers>
       <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </httpHandlers>
     <pages>
       <namespaces>
@@ -71,6 +72,7 @@
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
       <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/Getting-Started/ASP.NET-MVC/Create-Word-document/packages.config
+++ b/Getting-Started/ASP.NET-MVC/Create-Word-document/packages.config
@@ -13,6 +13,6 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/Getting-Started/ASP.NET/Create-Word-document/Create-Word-document.csproj
+++ b/Getting-Started/ASP.NET/Create-Word-document/Create-Word-document.csproj
@@ -45,17 +45,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />

--- a/Getting-Started/ASP.NET/Create-Word-document/Web.config
+++ b/Getting-Started/ASP.NET/Create-Word-document/Web.config
@@ -20,6 +20,7 @@
     </pages>
     <httpHandlers>
       <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </httpHandlers>
   </system.web>
   <runtime>
@@ -53,6 +54,7 @@
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
       <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/Getting-Started/ASP.NET/Create-Word-document/packages.config
+++ b/Getting-Started/ASP.NET/Create-Word-document/packages.config
@@ -13,6 +13,6 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/Getting-Started/WPF/Create-Word-document/Create-Word-document.csproj
+++ b/Getting-Started/WPF/Create-Word-document/Create-Word-document.csproj
@@ -36,17 +36,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.Wpf.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.Wpf.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Getting-Started/WPF/Create-Word-document/packages.config
+++ b/Getting-Started/WPF/Create-Word-document/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Getting-Started/Windows-Forms/Create-Word-document/Create-Word-document.csproj
+++ b/Getting-Started/Windows-Forms/Create-Word-document/Create-Word-document.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Getting-Started/Windows-Forms/Create-Word-document/packages.config
+++ b/Getting-Started/Windows-Forms/Create-Word-document/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/HTML-conversions/Customize-HTML-to-Word-conversion/.NET-Framework/Customize-HTML-to-Word-conversion/Customize-HTML-to-Word-conversion.csproj
+++ b/HTML-conversions/Customize-HTML-to-Word-conversion/.NET-Framework/Customize-HTML-to-Word-conversion/Customize-HTML-to-Word-conversion.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/HTML-conversions/Customize-HTML-to-Word-conversion/.NET-Framework/Customize-HTML-to-Word-conversion/packages.config
+++ b/HTML-conversions/Customize-HTML-to-Word-conversion/.NET-Framework/Customize-HTML-to-Word-conversion/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/HTML-conversions/Customize-Word-to-HTML-conversion/.NET-Framework/Customize-Word-to-HTML-conversion/Customize-Word-to-HTML-conversion.csproj
+++ b/HTML-conversions/Customize-Word-to-HTML-conversion/.NET-Framework/Customize-Word-to-HTML-conversion/Customize-Word-to-HTML-conversion.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/HTML-conversions/Customize-Word-to-HTML-conversion/.NET-Framework/Customize-Word-to-HTML-conversion/packages.config
+++ b/HTML-conversions/Customize-Word-to-HTML-conversion/.NET-Framework/Customize-Word-to-HTML-conversion/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/HTML-conversions/Extract-images-when-export-to-HTML/.NET-Framework/Extract-images-when-export-to-HTML/Extract-images-when-export-to-HTML.csproj
+++ b/HTML-conversions/Extract-images-when-export-to-HTML/.NET-Framework/Extract-images-when-export-to-HTML/Extract-images-when-export-to-HTML.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/HTML-conversions/Extract-images-when-export-to-HTML/.NET-Framework/Extract-images-when-export-to-HTML/packages.config
+++ b/HTML-conversions/Extract-images-when-export-to-HTML/.NET-Framework/Extract-images-when-export-to-HTML/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Generate-certificate-for-employees/.NET-Framework/Generate-certificate-for-employees/Generate-certificate-for-employees.csproj
+++ b/Mail-Merge/Generate-certificate-for-employees/.NET-Framework/Generate-certificate-for-employees/Generate-certificate-for-employees.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Generate-certificate-for-employees/.NET-Framework/Generate-certificate-for-employees/packages.config
+++ b/Mail-Merge/Generate-certificate-for-employees/.NET-Framework/Generate-certificate-for-employees/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Generate-letter-for-candidates-in-sorted-order/.NET-Framework/Generate-letter-for-candidates-in-sorted-order/Generate-letter-for-candidates-in-sorted-order.csproj
+++ b/Mail-Merge/Generate-letter-for-candidates-in-sorted-order/.NET-Framework/Generate-letter-for-candidates-in-sorted-order/Generate-letter-for-candidates-in-sorted-order.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Generate-letter-for-candidates-in-sorted-order/.NET-Framework/Generate-letter-for-candidates-in-sorted-order/packages.config
+++ b/Mail-Merge/Generate-letter-for-candidates-in-sorted-order/.NET-Framework/Generate-letter-for-candidates-in-sorted-order/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Generate-letter-for-filtered-contacts/.NET-Framework/Generate-letter-for-filtered-contacts/Generate-letter-for-filtered-contacts.csproj
+++ b/Mail-Merge/Generate-letter-for-filtered-contacts/.NET-Framework/Generate-letter-for-filtered-contacts/Generate-letter-for-filtered-contacts.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Generate-letter-for-filtered-contacts/.NET-Framework/Generate-letter-for-filtered-contacts/packages.config
+++ b/Mail-Merge/Generate-letter-for-filtered-contacts/.NET-Framework/Generate-letter-for-filtered-contacts/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Generate-multiple-Word-documents/.NET-Framework/Generate-multiple-Word-documents/Generate-multiple-Word-documents.csproj
+++ b/Mail-Merge/Generate-multiple-Word-documents/.NET-Framework/Generate-multiple-Word-documents/Generate-multiple-Word-documents.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Generate-multiple-Word-documents/.NET-Framework/Generate-multiple-Word-documents/packages.config
+++ b/Mail-Merge/Generate-multiple-Word-documents/.NET-Framework/Generate-multiple-Word-documents/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Generate-notice-to-renew-lease/.NET-Framework/Generate-notice-to-renew-lease/Generate-notice-to-renew-lease.csproj
+++ b/Mail-Merge/Generate-notice-to-renew-lease/.NET-Framework/Generate-notice-to-renew-lease/Generate-notice-to-renew-lease.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Generate-notice-to-renew-lease/.NET-Framework/Generate-notice-to-renew-lease/packages.config
+++ b/Mail-Merge/Generate-notice-to-renew-lease/.NET-Framework/Generate-notice-to-renew-lease/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Generate-payroll-for-employees/.NET-Framework/Generate-payroll-for-employees/Generate-payroll-for-employees.csproj
+++ b/Mail-Merge/Generate-payroll-for-employees/.NET-Framework/Generate-payroll-for-employees/Generate-payroll-for-employees.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Generate-payroll-for-employees/.NET-Framework/Generate-payroll-for-employees/packages.config
+++ b/Mail-Merge/Generate-payroll-for-employees/.NET-Framework/Generate-payroll-for-employees/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Generate-sales-invoice/WPF/Generate-sales-invoice/Generate-sales-invoice.csproj
+++ b/Mail-Merge/Generate-sales-invoice/WPF/Generate-sales-invoice/Generate-sales-invoice.csproj
@@ -36,20 +36,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.Wpf.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.Wpf.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Shared.WPF.27.1.53\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Shared.WPF.28.1.33\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Mail-Merge/Generate-sales-invoice/WPF/Generate-sales-invoice/packages.config
+++ b/Mail-Merge/Generate-sales-invoice/WPF/Generate-sales-invoice/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Group-customers-based-on-products/.NET-Framework/Group-customers-based-on-products/Group-customers-based-on-products.csproj
+++ b/Mail-Merge/Group-customers-based-on-products/.NET-Framework/Group-customers-based-on-products/Group-customers-based-on-products.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Group-customers-based-on-products/.NET-Framework/Group-customers-based-on-products/packages.config
+++ b/Mail-Merge/Group-customers-based-on-products/.NET-Framework/Group-customers-based-on-products/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Mail-merge-for-group/.NET-Framework/Mail-merge-for-group/Mail-merge-for-group.csproj
+++ b/Mail-Merge/Mail-merge-for-group/.NET-Framework/Mail-merge-for-group/Mail-merge-for-group.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Mail-merge-for-group/.NET-Framework/Mail-merge-for-group/packages.config
+++ b/Mail-Merge/Mail-merge-for-group/.NET-Framework/Mail-merge-for-group/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Mail-merge-using-OleDbConnection/.NET-Framework/Mail-merge-using-OleDbConnection/Mail-merge-using-OleDbConnection.csproj
+++ b/Mail-Merge/Mail-merge-using-OleDbConnection/.NET-Framework/Mail-merge-using-OleDbConnection/Mail-merge-using-OleDbConnection.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Mail-merge-using-OleDbConnection/.NET-Framework/Mail-merge-using-OleDbConnection/packages.config
+++ b/Mail-Merge/Mail-merge-using-OleDbConnection/.NET-Framework/Mail-merge-using-OleDbConnection/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Mail-merge-with-explicit-relational-data/.NET-Framework/Mail-merge-with-explicit-relational-data/Mail-merge-with-explicit-relational-data.csproj
+++ b/Mail-Merge/Mail-merge-with-explicit-relational-data/.NET-Framework/Mail-merge-with-explicit-relational-data/Mail-merge-with-explicit-relational-data.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Mail-merge-with-explicit-relational-data/.NET-Framework/Mail-merge-with-explicit-relational-data/packages.config
+++ b/Mail-Merge/Mail-merge-with-explicit-relational-data/.NET-Framework/Mail-merge-with-explicit-relational-data/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Mail-Merge/Replace-Merge-field-with-HTML/.NET Framework/Replace-Merge-field-with-HTML/Replace-Merge-field-with-HTML.csproj
+++ b/Mail-Merge/Replace-Merge-field-with-HTML/.NET Framework/Replace-Merge-field-with-HTML/Replace-Merge-field-with-HTML.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Mail-Merge/Replace-Merge-field-with-HTML/.NET Framework/Replace-Merge-field-with-HTML/packages.config
+++ b/Mail-Merge/Replace-Merge-field-with-HTML/.NET Framework/Replace-Merge-field-with-HTML/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Read-and-Save-document/Open-and-save-Word-document/.NET-Framework/Open-and-save-Word-document/Open-and-save-Word-document.csproj
+++ b/Read-and-Save-document/Open-and-save-Word-document/.NET-Framework/Open-and-save-Word-document/Open-and-save-Word-document.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Read-and-Save-document/Open-and-save-Word-document/.NET-Framework/Open-and-save-Word-document/packages.config
+++ b/Read-and-Save-document/Open-and-save-Word-document/.NET-Framework/Open-and-save-Word-document/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Read-and-Save-document/Open-and-save-Word-document/ASP.NET-MVC/Open-and-save-Word-document/Open-and-save-Word-document.csproj
+++ b/Read-and-Save-document/Open-and-save-Word-document/ASP.NET-MVC/Open-and-save-Word-document/Open-and-save-Word-document.csproj
@@ -46,17 +46,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Read-and-Save-document/Open-and-save-Word-document/ASP.NET-MVC/Open-and-save-Word-document/Web.config
+++ b/Read-and-Save-document/Open-and-save-Word-document/ASP.NET-MVC/Open-and-save-Word-document/Web.config
@@ -18,6 +18,7 @@
     <httpRuntime targetFramework="4.6.2" />
     <httpHandlers>
       <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </httpHandlers>
     <pages>
       <namespaces>
@@ -71,6 +72,7 @@
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
       <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/Read-and-Save-document/Open-and-save-Word-document/ASP.NET-MVC/Open-and-save-Word-document/packages.config
+++ b/Read-and-Save-document/Open-and-save-Word-document/ASP.NET-MVC/Open-and-save-Word-document/packages.config
@@ -13,6 +13,6 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/Read-and-Save-document/Open-and-save-Word-document/ASP.NET/Open-and-save-Word-document/Open-and-save-Word-document.csproj
+++ b/Read-and-Save-document/Open-and-save-Word-document/ASP.NET/Open-and-save-Word-document/Open-and-save-Word-document.csproj
@@ -45,17 +45,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />

--- a/Read-and-Save-document/Open-and-save-Word-document/ASP.NET/Open-and-save-Word-document/Web.config
+++ b/Read-and-Save-document/Open-and-save-Word-document/ASP.NET/Open-and-save-Word-document/Web.config
@@ -20,6 +20,7 @@
     </pages>
     <httpHandlers>
       <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </httpHandlers>
   </system.web>
   <runtime>
@@ -53,6 +54,7 @@
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
       <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/Read-and-Save-document/Open-and-save-Word-document/ASP.NET/Open-and-save-Word-document/packages.config
+++ b/Read-and-Save-document/Open-and-save-Word-document/ASP.NET/Open-and-save-Word-document/packages.config
@@ -13,6 +13,6 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/Read-and-Save-document/Open-and-save-Word-document/WPF/Open-and-save-Word-document/Open-and-save-Word-document.csproj
+++ b/Read-and-Save-document/Open-and-save-Word-document/WPF/Open-and-save-Word-document/Open-and-save-Word-document.csproj
@@ -36,17 +36,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.Wpf.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.Wpf.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Read-and-Save-document/Open-and-save-Word-document/WPF/Open-and-save-Word-document/packages.config
+++ b/Read-and-Save-document/Open-and-save-Word-document/WPF/Open-and-save-Word-document/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Read-and-Save-document/Open-and-save-Word-document/Windows-Forms/Open-and-save-Word-document/Open-and-save-Word-document.csproj
+++ b/Read-and-Save-document/Open-and-save-Word-document/Windows-Forms/Open-and-save-Word-document/Open-and-save-Word-document.csproj
@@ -34,16 +34,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Syncfusion.Compression.Base, Version=27.1400.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net40\Syncfusion.Compression.Base.dll</HintPath>
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net40\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.DocIO.Base, Version=27.1400.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net40\Syncfusion.DocIO.Base.dll</HintPath>
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net40\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net45\Syncfusion.Licensing.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1400.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net40\Syncfusion.OfficeChart.Base.dll</HintPath>
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net40\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Read-and-Save-document/Open-and-save-Word-document/Windows-Forms/Open-and-save-Word-document/packages.config
+++ b/Read-and-Save-document/Open-and-save-Word-document/Windows-Forms/Open-and-save-Word-document/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net46" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net46" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net46" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net46" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net46" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net46" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net46" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net46" />
 </packages>

--- a/Read-and-Save-document/Open-read-only-Word-document/.NET-Framework/Open-read-only-Word-document/Open-read-only-Word-document.csproj
+++ b/Read-and-Save-document/Open-read-only-Word-document/.NET-Framework/Open-read-only-Word-document/Open-read-only-Word-document.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Read-and-Save-document/Open-read-only-Word-document/.NET-Framework/Open-read-only-Word-document/packages.config
+++ b/Read-and-Save-document/Open-read-only-Word-document/.NET-Framework/Open-read-only-Word-document/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Read-and-Save-document/Send-Word-to-client-browser/ASP.NET/Send-Word-to-client-browser/Send-Word-to-client-browser.csproj
+++ b/Read-and-Save-document/Send-Word-to-client-browser/ASP.NET/Send-Word-to-client-browser/Send-Word-to-client-browser.csproj
@@ -45,17 +45,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />

--- a/Read-and-Save-document/Send-Word-to-client-browser/ASP.NET/Send-Word-to-client-browser/Web.config
+++ b/Read-and-Save-document/Send-Word-to-client-browser/ASP.NET/Send-Word-to-client-browser/Web.config
@@ -20,6 +20,7 @@
     </pages>
     <httpHandlers>
       <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </httpHandlers>
   </system.web>
   <runtime>
@@ -53,6 +54,7 @@
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
       <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/Read-and-Save-document/Send-Word-to-client-browser/ASP.NET/Send-Word-to-client-browser/packages.config
+++ b/Read-and-Save-document/Send-Word-to-client-browser/ASP.NET/Send-Word-to-client-browser/packages.config
@@ -13,6 +13,6 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/Sections/Add-default-header-and-footer/.NET-Framework/Add-default-header-and-footer/Add-default-header-and-footer.csproj
+++ b/Sections/Add-default-header-and-footer/.NET-Framework/Add-default-header-and-footer/Add-default-header-and-footer.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Sections/Add-default-header-and-footer/.NET-Framework/Add-default-header-and-footer/packages.config
+++ b/Sections/Add-default-header-and-footer/.NET-Framework/Add-default-header-and-footer/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Tables/Insert-Row-with-same-formatting/.NET-Framework/Insert-Row-with-same-formatting/Insert-Row-with-same-formatting.csproj
+++ b/Tables/Insert-Row-with-same-formatting/.NET-Framework/Insert-Row-with-same-formatting/Insert-Row-with-same-formatting.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Tables/Insert-Row-with-same-formatting/.NET-Framework/Insert-Row-with-same-formatting/packages.config
+++ b/Tables/Insert-Row-with-same-formatting/.NET-Framework/Insert-Row-with-same-formatting/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-document/Extract-images-from-Word-document/.NET-Framework/Extract-images-from-Word-document/Extract-images-from-Word-document.csproj
+++ b/Word-document/Extract-images-from-Word-document/.NET-Framework/Extract-images-from-Word-document/Extract-images-from-Word-document.csproj
@@ -33,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-document/Extract-images-from-Word-document/.NET-Framework/Extract-images-from-Word-document/packages.config
+++ b/Word-document/Extract-images-from-Word-document/.NET-Framework/Extract-images-from-Word-document/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net48" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net48" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net48" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net48" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net48" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net48" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net48" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net48" />
 </packages>

--- a/Word-document/Print-Word-document/.NET-Framework/Print-Word-document/Print-Word-document.csproj
+++ b/Word-document/Print-Word-document/.NET-Framework/Print-Word-document/Print-Word-document.csproj
@@ -69,23 +69,23 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Shared.Base.27.1.53\lib\net462\Syncfusion.Shared.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Shared.Base.28.1.33\lib\net462\Syncfusion.Shared.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Tools.Windows, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Tools.Windows.27.1.53\lib\net462\Syncfusion.Tools.Windows.dll</HintPath>
+    <Reference Include="Syncfusion.Tools.Windows, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Tools.Windows.28.1.33\lib\net462\Syncfusion.Tools.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/Word-document/Print-Word-document/.NET-Framework/Print-Word-document/packages.config
+++ b/Word-document/Print-Word-document/.NET-Framework/Print-Word-document/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Shared.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Tools.Windows" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Shared.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Tools.Windows" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-document/Set-page-field-for-each-section/.NET-Framework/Set-page-field-for-each-section/Set-page-field-for-each-section.csproj
+++ b/Word-document/Set-page-field-for-each-section/.NET-Framework/Set-page-field-for-each-section/Set-page-field-for-each-section.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-document/Set-page-field-for-each-section/.NET-Framework/Set-page-field-for-each-section/packages.config
+++ b/Word-document/Set-page-field-for-each-section/.NET-Framework/Set-page-field-for-each-section/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-document/Silent-Printing-Word-Document/WinForms/Silent-Printing-Word-Document/Silent-Printing-Word-Document.csproj
+++ b/Word-document/Silent-Printing-Word-Document/WinForms/Silent-Printing-Word-Document/Silent-Printing-Word-Document.csproj
@@ -69,23 +69,23 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Shared.Base.27.1.53\lib\net462\Syncfusion.Shared.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Shared.Base.28.1.33\lib\net462\Syncfusion.Shared.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Tools.Windows, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Tools.Windows.27.1.53\lib\net462\Syncfusion.Tools.Windows.dll</HintPath>
+    <Reference Include="Syncfusion.Tools.Windows, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Tools.Windows.28.1.33\lib\net462\Syncfusion.Tools.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/Word-document/Silent-Printing-Word-Document/WinForms/Silent-Printing-Word-Document/packages.config
+++ b/Word-document/Silent-Printing-Word-Document/WinForms/Silent-Printing-Word-Document/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Shared.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Tools.Windows" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Shared.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Tools.Windows" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-EPUB-conversion/Convert-Word-to-EPUB/.NET-Framework/Convert-Word-to-EPUB/Convert-Word-to-EPUB.csproj
+++ b/Word-to-EPUB-conversion/Convert-Word-to-EPUB/.NET-Framework/Convert-Word-to-EPUB/Convert-Word-to-EPUB.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-EPUB-conversion/Convert-Word-to-EPUB/.NET-Framework/Convert-Word-to-EPUB/packages.config
+++ b/Word-to-EPUB-conversion/Convert-Word-to-EPUB/.NET-Framework/Convert-Word-to-EPUB/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-EPUB-conversion/Set-title-for-EPUB/.NET-Framework/Set-title-for-EPUB/Set-title-for-EPUB.csproj
+++ b/Word-to-EPUB-conversion/Set-title-for-EPUB/.NET-Framework/Set-title-for-EPUB/Set-title-for-EPUB.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-EPUB-conversion/Set-title-for-EPUB/.NET-Framework/Set-title-for-EPUB/packages.config
+++ b/Word-to-EPUB-conversion/Set-title-for-EPUB/.NET-Framework/Set-title-for-EPUB/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-Image-conversion/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/Convert-Word-to-image.csproj
+++ b/Word-to-Image-conversion/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/Convert-Word-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-Image-conversion/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/packages.config
+++ b/Word-to-Image-conversion/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET-MVC/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
+++ b/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET-MVC/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
@@ -46,17 +46,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET-MVC/Convert-Word-Document-to-Image/Web.config
+++ b/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET-MVC/Convert-Word-Document-to-Image/Web.config
@@ -18,6 +18,7 @@
     <httpRuntime targetFramework="4.6.2" />
     <httpHandlers>
       <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </httpHandlers>
     <pages>
       <namespaces>
@@ -71,6 +72,7 @@
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
       <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET-MVC/Convert-Word-Document-to-Image/packages.config
+++ b/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET-MVC/Convert-Word-Document-to-Image/packages.config
@@ -13,6 +13,6 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
+++ b/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
@@ -44,17 +44,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />

--- a/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET/Convert-Word-Document-to-Image/Web.config
+++ b/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET/Convert-Word-Document-to-Image/Web.config
@@ -12,6 +12,7 @@
     <httpRuntime targetFramework="4.6.2" />
     <httpHandlers>
       <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </httpHandlers>
     <pages>
       <namespaces>
@@ -29,6 +30,7 @@
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
       <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET/Convert-Word-Document-to-Image/packages.config
+++ b/Word-to-Image-conversion/Convert-Word-to-image/ASP.NET/Convert-Word-Document-to-Image/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-Image-conversion/Convert-Word-to-image/WPF/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
+++ b/Word-to-Image-conversion/Convert-Word-to-image/WPF/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
@@ -36,17 +36,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.Wpf.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.Wpf.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Word-to-Image-conversion/Convert-Word-to-image/WPF/Convert-Word-Document-to-Image/packages.config
+++ b/Word-to-Image-conversion/Convert-Word-to-image/WPF/Convert-Word-Document-to-Image/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-Image-conversion/Convert-Word-to-image/WindowForms/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
+++ b/Word-to-Image-conversion/Convert-Word-to-image/WindowForms/Convert-Word-Document-to-Image/Convert-Word-Document-to-Image.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-Image-conversion/Convert-Word-to-image/WindowForms/Convert-Word-Document-to-Image/packages.config
+++ b/Word-to-Image-conversion/Convert-Word-to-image/WindowForms/Convert-Word-Document-to-Image/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-Image-conversion/Convert_all_pages_to_images/NET-Framework/Convert_all_pages_to_images/Convert_all_pages_to_images.csproj
+++ b/Word-to-Image-conversion/Convert_all_pages_to_images/NET-Framework/Convert_all_pages_to_images/Convert_all_pages_to_images.csproj
@@ -33,29 +33,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-Image-conversion/Convert_all_pages_to_images/NET-Framework/Convert_all_pages_to_images/packages.config
+++ b/Word-to-Image-conversion/Convert_all_pages_to_images/NET-Framework/Convert_all_pages_to_images/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-Image-conversion/Custom-image-resolution/.NET-Framework/Custom-image-resolution/Custom-image-resolution.csproj
+++ b/Word-to-Image-conversion/Custom-image-resolution/.NET-Framework/Custom-image-resolution/Custom-image-resolution.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-Image-conversion/Custom-image-resolution/.NET-Framework/Custom-image-resolution/packages.config
+++ b/Word-to-Image-conversion/Custom-image-resolution/.NET-Framework/Custom-image-resolution/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-Image-conversion/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/First-page-of-Word-to-image.csproj
+++ b/Word-to-Image-conversion/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/First-page-of-Word-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-Image-conversion/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/packages.config
+++ b/Word-to-Image-conversion/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-Image-conversion/Specific-range-of-pages-Word-to-image/.NET-Framework/Specific-range-of-pages-Word-to-image/Specific-range-of-pages-Word-to-image.csproj
+++ b/Word-to-Image-conversion/Specific-range-of-pages-Word-to-image/.NET-Framework/Specific-range-of-pages-Word-to-image/Specific-range-of-pages-Word-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-Image-conversion/Specific-range-of-pages-Word-to-image/.NET-Framework/Specific-range-of-pages-Word-to-image/packages.config
+++ b/Word-to-Image-conversion/Specific-range-of-pages-Word-to-image/.NET-Framework/Specific-range-of-pages-Word-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Adjust-image-quality/.NET-Framework/Adjust-image-quality/Adjust-image-quality.csproj
+++ b/Word-to-PDF-Conversion/Adjust-image-quality/.NET-Framework/Adjust-image-quality/Adjust-image-quality.csproj
@@ -34,29 +34,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Adjust-image-quality/.NET-Framework/Adjust-image-quality/packages.config
+++ b/Word-to-PDF-Conversion/Adjust-image-quality/.NET-Framework/Adjust-image-quality/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Convert-5-pages-in-Word-to-PDF/.NET-Framework/Convert-5-pages-in-Word-to-PDF/Convert-5-pages-in-Word-to-PDF.csproj
+++ b/Word-to-PDF-Conversion/Convert-5-pages-in-Word-to-PDF/.NET-Framework/Convert-5-pages-in-Word-to-PDF/Convert-5-pages-in-Word-to-PDF.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Convert-5-pages-in-Word-to-PDF/.NET-Framework/Convert-5-pages-in-Word-to-PDF/packages.config
+++ b/Word-to-PDF-Conversion/Convert-5-pages-in-Word-to-PDF/.NET-Framework/Convert-5-pages-in-Word-to-PDF/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/.NET-Framework/Convert-Word-document-to-PDF/Convert-Word-document-to-PDF.csproj
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/.NET-Framework/Convert-Word-document-to-PDF/Convert-Word-document-to-PDF.csproj
@@ -34,29 +34,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/.NET-Framework/Convert-Word-document-to-PDF/packages.config
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/.NET-Framework/Convert-Word-document-to-PDF/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET-MVC/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET-MVC/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
@@ -46,23 +46,23 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET-MVC/Convert-Word-Document-to-PDF/Web.config
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET-MVC/Convert-Word-Document-to-PDF/Web.config
@@ -18,6 +18,7 @@
     <httpRuntime targetFramework="4.6.2" />
     <httpHandlers>
       <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </httpHandlers>
     <pages>
       <namespaces>
@@ -71,6 +72,7 @@
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
       <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET-MVC/Convert-Word-Document-to-PDF/packages.config
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET-MVC/Convert-Word-Document-to-PDF/packages.config
@@ -13,8 +13,8 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPdfConverter.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPdfConverter.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
@@ -45,23 +45,23 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPdfConverter.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1450.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.AspNet.Mvc5.27.1.53\lib\net45\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.AspNet.Mvc5.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET/Convert-Word-Document-to-PDF/Web.config
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET/Convert-Word-Document-to-PDF/Web.config
@@ -20,6 +20,7 @@
     </pages>
     <httpHandlers>
       <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </httpHandlers>
   </system.web>
   <runtime>
@@ -53,6 +54,7 @@
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
       <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=27.1450.53, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
+      <add verb="*" path="captimage.axd" name="syncfusion_generatetools" type="Syncfusion.JavaScript.ImageHandler, Syncfusion.EJ, Version=28.14620.33, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET/Convert-Word-Document-to-PDF/packages.config
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/ASP.NET/Convert-Word-Document-to-PDF/packages.config
@@ -13,8 +13,8 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPdfConverter.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.AspNet.Mvc5" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPdfConverter.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.AspNet.Mvc5" version="28.1.33" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/WPF/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/WPF/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
@@ -36,23 +36,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.Wpf.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.Wpf.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.Wpf.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.Wpf.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.Wpf.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.Wpf.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/WPF/Convert-Word-Document-to-PDF/packages.config
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/WPF/Convert-Word-Document-to-PDF/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.Wpf" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.Wpf" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/WindowForms/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/WindowForms/Convert-Word-Document-to-PDF/Convert-Word-Document-to-PDF.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/WindowForms/Convert-Word-Document-to-PDF/packages.config
+++ b/Word-to-PDF-Conversion/Convert-Word-document-to-PDF/WindowForms/Convert-Word-Document-to-PDF/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Dictionary-Event-Handler-in-Word-to-PDF/.NET-Framework/Dictionary-Event-Handler-in-Word-to-PDF/Dictionary-Event-Handler-in-Word-to-PDF.csproj
+++ b/Word-to-PDF-Conversion/Dictionary-Event-Handler-in-Word-to-PDF/.NET-Framework/Dictionary-Event-Handler-in-Word-to-PDF/Dictionary-Event-Handler-in-Word-to-PDF.csproj
@@ -34,29 +34,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Dictionary-Event-Handler-in-Word-to-PDF/.NET-Framework/Dictionary-Event-Handler-in-Word-to-PDF/packages.config
+++ b/Word-to-PDF-Conversion/Dictionary-Event-Handler-in-Word-to-PDF/.NET-Framework/Dictionary-Event-Handler-in-Word-to-PDF/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Enable-fast-rendering/.NET-Framework/Enable-fast-rendering/Enable-fast-rendering.csproj
+++ b/Word-to-PDF-Conversion/Enable-fast-rendering/.NET-Framework/Enable-fast-rendering/Enable-fast-rendering.csproj
@@ -34,29 +34,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Enable-fast-rendering/.NET-Framework/Enable-fast-rendering/packages.config
+++ b/Word-to-PDF-Conversion/Enable-fast-rendering/.NET-Framework/Enable-fast-rendering/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Get-missing-fonts-for-pdf-conversion/WindowsForms/Get-missing-fonts-for-PDF-conversion/Get-missing-fonts-for-PDF-conversion.csproj
+++ b/Word-to-PDF-Conversion/Get-missing-fonts-for-pdf-conversion/WindowsForms/Get-missing-fonts-for-PDF-conversion/Get-missing-fonts-for-PDF-conversion.csproj
@@ -33,29 +33,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Get-missing-fonts-for-pdf-conversion/WindowsForms/Get-missing-fonts-for-PDF-conversion/packages.config
+++ b/Word-to-PDF-Conversion/Get-missing-fonts-for-pdf-conversion/WindowsForms/Get-missing-fonts-for-PDF-conversion/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Ole-Equation-as-bitmap/.NET-Framework/Ole-Equation-as-bitmap/Ole-Equation-as-bitmap.csproj
+++ b/Word-to-PDF-Conversion/Ole-Equation-as-bitmap/.NET-Framework/Ole-Equation-as-bitmap/Ole-Equation-as-bitmap.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Ole-Equation-as-bitmap/.NET-Framework/Ole-Equation-as-bitmap/packages.config
+++ b/Word-to-PDF-Conversion/Ole-Equation-as-bitmap/.NET-Framework/Ole-Equation-as-bitmap/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Recreate-nested-metafile/.NET-Framework/Recreate-nested-metafile/Recreate-nested-metafile.csproj
+++ b/Word-to-PDF-Conversion/Recreate-nested-metafile/.NET-Framework/Recreate-nested-metafile/Recreate-nested-metafile.csproj
@@ -34,29 +34,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WPF.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Recreate-nested-metafile/.NET-Framework/Recreate-nested-metafile/packages.config
+++ b/Word-to-PDF-Conversion/Recreate-nested-metafile/.NET-Framework/Recreate-nested-metafile/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WPF" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Word-to-PDF-Conversion/Reduce-pdf-size/.NET Framework/Reduce-pdf-size/Reduce-pdf-size.csproj
+++ b/Word-to-PDF-Conversion/Reduce-pdf-size/.NET Framework/Reduce-pdf-size/Reduce-pdf-size.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.27.1.53\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.28.1.33\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.27.1.53\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.28.1.33\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Word-to-PDF-Conversion/Reduce-pdf-size/.NET Framework/Reduce-pdf-size/packages.config
+++ b/Word-to-PDF-Conversion/Reduce-pdf-size/.NET Framework/Reduce-pdf-size/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.WinForms" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="28.1.33" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Description:
Upgraded the NuGet version to 28.1.33 in all .NET Framework projects for DocIO Examples repository.